### PR TITLE
Add more linting and compile time checks

### DIFF
--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -1,0 +1,34 @@
+name: OpenRewrite Analysis
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # Allows manual trigger from Actions tab
+
+jobs:
+  rewrite:
+    name: OpenRewrite Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission
+        run: chmod +x gradlew
+
+      - name: Run OpenRewrite dry run
+        run: ./gradlew rewriteDryRun
+
+      - name: Upload rewrite report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rewrite-report
+          path: build/reports/rewrite/

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "2026.2.1"
     id "com.peterabeles.gversion" version "1.10"
     id 'com.github.spotbugs' version '6.0.26'
+    id 'net.ltgt.errorprone' version '5.1.0'
+    id 'org.openrewrite.rewrite' version '7.30.0'
 }
 
 java {
@@ -79,6 +81,13 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
     onlyIf {
         gradle.startParameter.taskNames.any { it.toLowerCase().contains('spotbugs') }
     }
+}
+
+// OpenRewrite automated code cleanup and modernization
+// Apply fixes:   ./gradlew rewriteRun
+// Preview only:  ./gradlew rewriteDryRun
+rewrite {
+    activeRecipe('org.openrewrite.staticanalysis.CommonStaticAnalysis')
 }
 
 // Spotless formatting
@@ -215,6 +224,12 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Error Prone 2.43+ requires Java 21; 2.42.0 is the last Java-17-compatible release
+    errorprone 'com.google.errorprone:error_prone_core:2.42.0'
+
+    rewrite platform('org.openrewrite.recipe:rewrite-recipe-bom:3.28.0')
+    rewrite 'org.openrewrite.recipe:rewrite-static-analysis'
 }
 
 test {
@@ -266,4 +281,16 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// Error Prone static analysis — runs at compile time as part of ./gradlew build
+// Findings at ERROR severity fail the build; WARNING severity are informational.
+// To disable a specific check: options.errorprone.disable('CheckName')
+// To demote a check to warning: options.errorprone.warn('CheckName')
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableWarningsInGeneratedCode = true
+        // Exclude auto-generated files and vendor utilities we don't own
+        excludedPaths = '.*/BuildConstants\\.java|.*/LimelightHelpers\\.java'
+    }
 }

--- a/src/main/java/frc/robot/subsystems/Intake/IntakePivot/IntakePivotIOSim.java
+++ b/src/main/java/frc/robot/subsystems/Intake/IntakePivot/IntakePivotIOSim.java
@@ -142,11 +142,6 @@ public class IntakePivotIOSim implements IntakePivotIO {
     visualizer.update(intakePivotSim.getAngleRads());
   }
 
-  /**
-   * Set position using PID control with gravity compensation.
-   *
-   * @param positionRotations Target position in rotations
-   */
   public void setZero() {
     motorControllerSim.setPosition(0.0);
   }
@@ -157,11 +152,13 @@ public class IntakePivotIOSim implements IntakePivotIO {
     motorControllerSim.setControl(positionRequest.withPosition(rotations));
   }
 
+  @Override
   public void setPositionSmooth(double positionDegrees) {
     double rotations = positionDegrees / 360.0;
     motorControllerSim.setControl(motionMagicRequest.withPosition(rotations));
   }
 
+  @Override
   public void setPositionAggressive(double positionDegrees) {
     double rotations = positionDegrees / 360.0;
     motorControllerSim.setControl(positionRequest.withPosition(rotations));

--- a/src/main/java/frc/robot/subsystems/Shooter/Hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Shooter/Hood/Hood.java
@@ -104,7 +104,7 @@ public class Hood extends SubsystemBase {
         // TODO: keep as is until we are confident with our localization to not default to ducking
         // when in PASSIVE_PREP mode. We currently call this for logging purposes to validate the
         // logic works
-        shouldDuck.getAsBoolean();
+        var unused = shouldDuck.getAsBoolean(); // called for logging side-effects only
         currentState = HoodInternalStates.ZEROING;
         break;
       case IDLE:


### PR DESCRIPTION
Also resolve a few things the linter caught, but there are a great many more. 

This won't fail the build due to warnings, but the compile time check will fail if we get something at the ERROR level. (there aren't any of those right now, and it seems like there should never be a reason to allow one through) I tested one example ERROR where an exception is created (new Exception) but never thrown, which is not a legitimate pattern.